### PR TITLE
API: Use id_str to avoid dealing with 64-bit integers in Javascript

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -164,26 +164,16 @@ var PushoverAPI = GObject.registerClass(
                     this.lg(msgs.length + " Pushover Messages received");
 
                     msgs.forEach((msg) => {
-                        let msgID = parseInt(msg.id);
+                        let msgID = msg.id_str;
 
-                        if (this.lastID != msgID) {
-                            this.lg("Message: " + msg.title + ": " + msg.message);
-                            this.lg("Message ID: " + msg.id);
+                        this.lg("Message: " + msg.title + ": " + msg.message);
+                        this.lg("Message ID: " + msg.id_str);
 
-                            //this.notify(msg.title, msg.message, msg.icon);
-                            result.push(msg);
+                        //this.notify(msg.title, msg.message, msg.icon);
+                        result.push(msg);
 
-                            if (msgID > this.lastID) {
-                                this.lastID = msgID;
-                            }
-                        } else {
-                            // Pushover has a bug where sometimes non-emergency messages with prio 0 keep being resent.
-                            // ignore these repetive messages to avoid obtrusive user impact. Pushover team is notified.
-
-                            this.lg('Duplicate message with ID:' + msgID);
-                            this.lg('priority:' + msg.priority);
-                            this.lg('acked:' + msg.acked);
-                            this.lg('receipt:' + msg.receipt);
+                        if (msgID > this.lastID) {
+                            this.lastID = msgID;
                         }
                     });
 


### PR DESCRIPTION
*[Note: I emailed this to you but never heard back, so I figured I'd just make a PR for it.  I haven't actually tested this code because I don't have a compatible environment. ]*

Javascript stores 64-bit integers as doubles, so parsing an ID returned by Pushover's API can end up rounding off the last few digits of the ID.  When this rounded value is fed back to Pushover's "update_highest_message" API call, it can be less than the actual highest ID that Pushover's messages API initially returned, so not all messages are getting deleted.  On the next message download, the remaining messages from the first download are still there, which caused duplicate notifications.

https://stackoverflow.com/questions/9643626/does-javascript-support-64-bit-integers/9643650#9643650