### PR TITLE
Update for Gnome 44

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,3 +1,4 @@
+imports.gi.versions.Soup = "2.4";
 const {
     GObject,
     GLib,

--- a/metadata.json
+++ b/metadata.json
@@ -6,9 +6,10 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/cwittenberg/gnome-pushover-messages-unofficial",
   "uuid": "gnome-pushover-messages-unofficial@iwont.cyou",
-  "version": 6
+  "version": 9
 }

--- a/preferences/generalPage.js
+++ b/preferences/generalPage.js
@@ -21,6 +21,7 @@
  *
  */
 
+imports.gi.versions.Soup = "2.4";
 const {
     GObject,
     GLib,


### PR DESCRIPTION
Update the metadata for Gnome 44 and use the old version of Soup for compatibility.